### PR TITLE
Fix forgotten semicolon

### DIFF
--- a/extensions/Spoilers/Spoilers.hooks.php
+++ b/extensions/Spoilers/Spoilers.hooks.php
@@ -35,7 +35,7 @@ class Spoilers {
 	static public function parseSpoilerTag( $input, array $args, Parser $parser, PPFrame $frame ) {
 		$out = $parser->getOutput();
 		$out->addModules( 'ext.spoilers' );
-		$renderedInput = $parser->recursiveTagParse( $input )
+		$renderedInput = $parser->recursiveTagParse( $input );
 		$output =	"<div class='spoilers'>
 						<div class='spoilers-button-container'>
 							<span class='spoilers-button'>

--- a/extensions/Spoilers/i18n/ru.json
+++ b/extensions/Spoilers/i18n/ru.json
@@ -1,0 +1,9 @@
+{
+	"@metadata": {
+		"authors": ["Tim Aldridge"]
+	},
+	"spoilers": "Spoilers",
+	"spoilers_description": "Тег спойлера - &lt;spoiler show=\"showMessage\" hide=\"hideMessage\"&gt;Скрытый текст&lt;/spoiler&gt;",
+	"spoilers_show_default": "Показать спойлер",
+	"spoilers_hide_default": "Скрыть спойлер"
+}


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected '$output' (T_VARIABLE)
