### PR TITLE
MediaWiki 1.25+ Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ Mediawiki extension that allows for spoiler tags that will hide a block of text.
 
 Installation
 ------------
-To install this extension, add the follwoing lines to the end of the LocalSettings.php file:
+To install this extension, add the following lines to the end of the LocalSettings.php file:
 ```
 //Spoilers
 require("$IP/extensions/Spoilers/Spoilers.php");
+```
+
+Or, if you are using MediaWiki 1.25+
+
+```
+//Spoilers
+wfLoadExtension('Spoilers');
 ```
 
 Usage Example

--- a/Spoilers.hooks.php
+++ b/Spoilers.hooks.php
@@ -10,28 +10,6 @@
  */
 class Spoilers {
 	/**
-	 * Hooks Initialized
-	 *
-	 * @var		boolean
-	 */
-	private static $initialized = false;
-
-	/**
-	 * Initiates some needed classes.
-	 *
-	 * @access	public
-	 * @return	void
-	 */
-	static public function init() {
-		global $wgOut;
-
-		if (!self::$initialized) {
-			$wgOut->addModules('ext.spoilers');
-			self::$initialized = true;
-		}
-	}
-
-	/**
 	 * Sets up this extensions parser functions.
 	 *
 	 * @access		public
@@ -41,7 +19,6 @@ class Spoilers {
 	 */
 	static public function onParserFirstCallInit( Parser &$parser ) {
 		$parser->setHook( "spoiler", "Spoilers::parseSpoilerTag" );
-
 		return true;
 	}
 
@@ -56,7 +33,7 @@ class Spoilers {
 	 * @return	string	HTML
 	 */
 	static public function parseSpoilerTag( $input, array $args, Parser $parser, PPFrame $frame ) {
-		self::init();
+		$parser->getOutput()->addmodules('ext.spoilers');
 		$renderedInput = $parser->recursiveTagParse( $input );
 		$output =	"<div class='spoilers'>
 						<div class='spoilers-button-container'>

--- a/Spoilers.php
+++ b/Spoilers.php
@@ -11,7 +11,7 @@
 
 # Only run if included by MediaWiki
 if ( !defined( 'MEDIAWIKI' ) ) die( 'Invalid entry point.' );
- 
+
 /******************************************/
 /* Credits                                */
 /******************************************/

--- a/extension.json
+++ b/extension.json
@@ -25,7 +25,7 @@
 		}
 	},
 	"ResourceFileModulePaths": {
-		"localBasePath": "",
+		"localBasePath": "/",
 		"remoteExtPath": "Spoilers"
 	},
 	"Hooks": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Spoilers",
-	"version": "1.2",
+	"version": "1.3",
 	"author": "Tim \"Telshin\" Aldridge",
 	"descriptionmsg": "spoilers_description",
 	"license-name": "LGPLv3",
@@ -9,9 +9,6 @@
 		"Spoilers": [
 			"i18n"
 		]
-	},
-	"ExtensionMessagesFiles": {
-		"Spoilers": "Spoilers.i18n.php"
 	},
 	"AutoloadClasses": {
 		"Spoilers": "Spoilers.hooks.php"
@@ -35,5 +32,6 @@
 		"ParserFirstCallInit": [
 			"Spoilers::onParserFirstCallInit"
 		]
-	}
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
- Updated extensions.json
- Modified hook file to properly handle resource loading.

If I was to bring this extension fully up to date, I would also remove the i18n shim, and the Spoilers.php would be changed into a MediaWiki 1.25 shim… but I have left those alone for compatibility.
