### PR TITLE
Show spoiler button text before first click

### DIFF
--- a/js/spoilers.js
+++ b/js/spoilers.js
@@ -2,12 +2,16 @@
 	'use strict';
 
 	function init() {
-		$('.spoilers-button').click(function() {
-			var $parent = $(this).parent(),
-				showMsg = $parent.attr('data-showtext') || mw.msg('spoilers_show_default'),
-				hideMsg = $parent.attr('data-hidetext') || mw.msg('spoilers_hide_default');
-			$parent.children('.spoilers-button').text($parent.children('.spolers-body:visible').length ? hideMsg : showMsg);
-			$parent.children('.spoilers-body').slideToggle();
+		$('.spoilers-button').each(function(i,elem){
+			var $elem   = $(elem),
+			    $parent = $elem.parent(),
+			    showMsg = $parent.attr('data-showtext') || mw.msg('spoilers_show_default'),
+			    hideMsg = $parent.attr('data-hidetext') || mw.msg('spoilers_hide_default');
+			$elem.text(showMsg);
+			$elem.click(function(){
+				$parent.children('.spoilers-button').text($parent.children('.spolers-body:visible').length ? hideMsg : showMsg);
+				$parent.children('.spoilers-body').slideToggle();
+			});
 		});
 	}
 


### PR DESCRIPTION
On first page load all spoiler buttons is little squares without text. Patch fixes issue #23
