### PR TITLE
Fix deprecation warning on use of `addModules()`

### DIFF
--- a/SpoilersHooks.php
+++ b/SpoilersHooks.php
@@ -39,7 +39,7 @@ class SpoilersHooks {
 	 */
 	public static function spoilerMagicWord( Parser &$parser, PPFrame $frame, array $args ) {
 		$params = self::extractOptions( $args, $frame );
-		$parser->getOutput()->addModules( 'ext.spoilers' );
+		$parser->getOutput()->addModules( ['ext.spoilers'] );
 		$output = self::generateOutput( $frame->expand( $params['text'] ), $params );
 
 		return [


### PR DESCRIPTION
When I ran this code in MediaWiki 1.38, I got this warning:

> Deprecated: Use of ParserOutput::addModules with non-array argument was deprecated in MediaWiki 1.38. [Called from Spoilers\SpoilersHooks::spoilerMagicWord in /w/extensions/Spoilers/SpoilersHooks.php at line 42] in /w/includes/debug/MWDebug.php on line 377

Sure enough, when I looked up the current documentation on `ParserOutput::addModules`, it expects one parameter of type `string[]`: https://doc.wikimedia.org/mediawiki-core/master/php/classParserOutput.html#a5aa5a14313a64b610dc9615be6e7b0d5

With the change in this commit, the above warning disappears.